### PR TITLE
xml always generated

### DIFF
--- a/scripts/single.py
+++ b/scripts/single.py
@@ -70,7 +70,7 @@ class RaiParser:
             rdata["podcast_info"]["dfp"].get("escaped_typology", []),
         )}
 
-        feed._data[f"{NSITUNES}category"] = [{"@text": c} for c in categories]
+        feed._data[f"{NSITUNES}category"] = [{"@text": c} for c in sorted(categories)]
 
         cards = rdata["block"].get("cards", [])
         feed.items = []


### PR DESCRIPTION
Ho notato che ogni volta che gira la pipeline modifica tutti i files.

Per evitare di avere una history lunga come una quaresima ho tentato di capire dove stesse il diff.

Queste `categories` sembrano essere sempre in posizione randomica, ordinandole per nome invece sembra che generino sempre lo stesso xml. 

```diff
- [{"@text": c} for c in categories]
+ [{"@text": c} for c in sorted(categories)]
```
